### PR TITLE
Refactor FirebaseAuthFilter to improve token verification and remove …

### DIFF
--- a/src/main/java/com/example/campusaura/security/FirebaseAuthFilter.java
+++ b/src/main/java/com/example/campusaura/security/FirebaseAuthFilter.java
@@ -1,7 +1,5 @@
 package com.example.campusaura.security;
 
-import com.example.campusaura.model.entity.User;
-import com.example.campusaura.service.UserService;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseToken;
 import jakarta.servlet.FilterChain;
@@ -13,29 +11,27 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.ArrayList;
 
 /**
- * Firebase Authentication Filter that integrates with Spring Security.
- * Validates Firebase ID tokens, syncs user to Firestore, and sets authentication in SecurityContext.
+ * Firebase Authentication Filter following industry best practices.
+ *
+ * CORRECT PATTERN:
+ * - Only verifies Firebase ID token
+ * - NO Firestore database calls
+ * - Stateless and fast
+ * - Role from Firebase custom claims
+
  */
 @Component
 public class FirebaseAuthFilter extends OncePerRequestFilter {
 
   private static final Logger logger = LoggerFactory.getLogger(FirebaseAuthFilter.class);
-
-  private final UserService userService;
-
-  public FirebaseAuthFilter(UserService userService) {
-    this.userService = userService;
-  }
 
   @Override
   protected void doFilterInternal(HttpServletRequest request,
@@ -49,66 +45,41 @@ public class FirebaseAuthFilter extends OncePerRequestFilter {
       String token = authHeader.substring(7);
 
       try {
+        // ONLY verify token - NO database calls
         FirebaseToken decodedToken = FirebaseAuth.getInstance().verifyIdToken(token);
 
-        // Sync user to Firestore (create if first login, fetch if existing)
-        User user = userService.getOrCreateUser(
-            decodedToken.getUid(),
-            decodedToken.getEmail(),
-            decodedToken.getName()
-        );
+        // Get role from Firebase custom claims (set during user registration)
+        // This is FAST - no database query needed
+        String role = (String) decodedToken.getClaims().getOrDefault("role", "STUDENT");
 
-        // Create custom principal with user details
-        FirebasePrincipal principal = new FirebasePrincipal(
-            user.getUid(),
-            user.getEmail(),
-            user.getName(),
-            decodedToken.getClaims()
-        );
-
-        // Use role from Firestore (source of truth for user data)
-        String role = user.getRole();
+        // Create authorities for Spring Security
         List<SimpleGrantedAuthority> authorities = Collections.singletonList(
             new SimpleGrantedAuthority("ROLE_" + role)
         );
 
-        // Create authentication token and set in SecurityContext
+        // Create authentication with UID as principal
+        // Simple and stateless - no custom objects needed
         UsernamePasswordAuthenticationToken authentication =
             new UsernamePasswordAuthenticationToken(
-                principal,
+                decodedToken.getUid(),  // UID as principal
                 null,
                 authorities
             );
 
-        authentication.setDetails(
-            new WebAuthenticationDetailsSource().buildDetails(request)
-        );
-
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        logger.debug("Authenticated user: {} with role: {}", user.getUid(), role);
-        // Set request attributes
-        request.setAttribute("uid", decodedToken.getUid());
-        request.setAttribute("email", decodedToken.getEmail());
+        // set UID, email, and name as request attributes for registration endpoints
+        request.setAttribute("firebaseUid", decodedToken.getUid());
+        request.setAttribute("firebaseEmail", decodedToken.getEmail());
+        request.setAttribute("firebaseName", decodedToken.getName());
 
-        // Create authentication token for Spring Security
-        UsernamePasswordAuthenticationToken authentication =
-            new UsernamePasswordAuthenticationToken(
-                decodedToken.getUid(),
-                null,
-                new ArrayList<>()
-            );
-        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-        // Set authentication in Spring Security context
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+        logger.debug("Authenticated user: {} with role: {}", decodedToken.getUid(), role);
 
       } catch (Exception e) {
         logger.error("Firebase token validation failed: {}", e.getMessage());
-        // Set status and let Spring Security handle the response
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
-        response.getWriter().write("{\"error\": \"Unauthorized\", \"message\": \"Invalid or expired token\"}");
+        response.getWriter().write("{\"error\":\"Unauthorized\",\"message\":\"Invalid or expired token\"}");
         return;
       }
     }


### PR DESCRIPTION
This pull request refactors the `FirebaseAuthFilter` to simplify and harden authentication logic by removing all database dependencies and ensuring the filter is stateless and fast. The filter now only verifies the Firebase ID token and derives the user's role from custom claims, aligning with industry best practices for stateless authentication.

**Refactor to stateless authentication:**

* Removed all Firestore/database calls and the dependency on `UserService` from `FirebaseAuthFilter`, making the filter stateless and focused solely on token validation. [[1]](diffhunk://#diff-9066b5421304f4ed9cc7defba35ba4587f38aad45aafe0dfb056cb1008bf1bdbL3-L4) [[2]](diffhunk://#diff-9066b5421304f4ed9cc7defba35ba4587f38aad45aafe0dfb056cb1008bf1bdbL16-L39)
* The user’s role is now sourced directly from Firebase custom claims in the ID token, eliminating the need for a database query.

**Simplification of authentication context:**

* The principal in the authentication token is now just the Firebase UID (no longer a custom principal object), and authorities are set based on the role from the token claims.
* Request attributes for UID, email, and name are set using values from the decoded token, with new attribute names (`firebaseUid`, `firebaseEmail`, `firebaseName`) for clarity and consistency.

**Documentation and comments:**

* Updated class-level and inline comments to clearly document the stateless, best-practice approach and removed outdated documentation about Firestore integration.