### PR TITLE
Backend prod

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,135 @@
+name: Deploy Backend to Azure Container Apps
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  ACR_REGISTRY: campusauraacr.azurecr.io
+  IMAGE_NAME: campusaura-backend
+  CONTAINER_APP_NAME: campusaura-backend
+  RESOURCE_GROUP: campusaura-rg
+  CONTAINER_APP_ENV: campusaura-env
+
+jobs:
+  # JOB 1: Build & Push Docker image to ACR
+  build-and-push:
+    name: Build & Push to ACR
+    runs-on: ubuntu-latest
+
+    outputs:
+      image-tag: ${{ steps.meta.outputs.tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate image tag
+        id: meta
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          echo "tag=sha-${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "Image tag: sha-${SHORT_SHA}"
+
+      - name: Log in to Azure Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ACR_REGISTRY }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.ACR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tag }}
+            ${{ env.ACR_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # JOB 2: Deploy to Azure Container Apps
+  deploy:
+    name: Deploy to Azure Container Apps
+    runs-on: ubuntu-latest
+    needs: build-and-push
+
+    steps:
+      - name: Log in to Azure
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Deploy to Azure Container Apps
+        run: |
+          IMAGE="${{ env.ACR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-and-push.outputs.image-tag }}"
+          echo "Deploying image: $IMAGE"
+
+          az containerapp update \
+            --name ${{ env.CONTAINER_APP_NAME }} \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --image "$IMAGE" \
+            --set-env-vars \
+              FIREBASE_SERVICE_ACCOUNT_KEY="base64:${{ secrets.FIREBASE_SERVICE_ACCOUNT_B64 }}" \
+              FIREBASE_DATABASE_URL="${{ secrets.FIREBASE_DATABASE_URL }}" \
+              SPRING_PROFILES_ACTIVE=prod \
+              SERVER_PORT=8080 \
+              CORS_ALLOWED_ORIGINS="${{ secrets.CORS_ALLOWED_ORIGINS }}"
+
+          echo "Deployment triggered. Waiting for active revision..."
+
+      - name: Wait for deployment to stabilize
+        run: |
+          echo "Waiting 30 seconds for revision to start..."
+          sleep 30
+
+          RUNNING=$(az containerapp revision list \
+            --name ${{ env.CONTAINER_APP_NAME }} \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --query "[?properties.active==\`true\`].properties.runningState" \
+            -o tsv)
+
+          echo "Running state: $RUNNING"
+
+          if [[ "$RUNNING" == *"Running"* ]]; then
+            echo "Container App is running."
+          else
+            echo "Container App may still be starting. Check Azure Portal for details."
+          fi
+
+  # JOB 3: Health Check
+  verify:
+    name: Health Check
+    runs-on: ubuntu-latest
+    needs: deploy
+
+    steps:
+      - name: Wait for app to be ready
+        run: sleep 30
+
+      - name: Run health check
+        run: |
+          URL="https://campusaura-backend.lemontree-0868690c.centralindia.azurecontainerapps.io/actuator/health"
+          echo "Checking health at: $URL"
+
+          for i in {1..5}; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL" --max-time 15)
+            echo "Attempt $i — HTTP $STATUS"
+
+            if [ "$STATUS" = "200" ]; then
+              echo "Health check passed!"
+              exit 0
+            fi
+
+            echo "Retrying in 20 seconds..."
+            sleep 20
+          done
+
+          echo "Health check failed after 5 attempts."
+          exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,33 @@
-# Stage 1: Build 
+# Stage 1: Build
 FROM maven:3.9.6-eclipse-temurin-17 AS build
 
 WORKDIR /app
 
-# Cache dependencies before copying source (faster rebuilds)
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 
-# Copy source and build JAR (skip tests — run them in CI)
 COPY src ./src
 RUN mvn clean package -DskipTests -B
+
 
 # Stage 2: Runtime
 FROM eclipse-temurin:17-jre-jammy
 
 WORKDIR /app
 
-# Install wget for healthcheck
-RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
-
-# Non-root user for security (required for Azure Container Apps)
+# Create non-root user
 RUN groupadd -r campusaura && useradd -r -g campusaura campusaura
-USER campusaura:campusaura
 
-# Copy JAR from build stage
+# Copy jar
 COPY --from=build --chown=campusaura:campusaura /app/target/*.jar app.jar
 
-# Port 8080 (default Spring Boot)
+USER campusaura:campusaura
+
 EXPOSE 8080
 
-# JVM tuning for containers (prevents OOM in cloud environments)
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0"
 
-# Health check — needs wget (installed above)
-HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://localhost:8080/actuator/health || exit 1
+# Optional: remove HEALTHCHECK entirely for Docker Compose
+# Azure / Render / Railway can do health checks externally
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   # Spring Boot Backend
   backend:
     build:
-      context: ./CampusAura-backend
+      context: .
       dockerfile: Dockerfile
     container_name: campusaura-backend
     ports:
@@ -16,7 +16,7 @@ services:
       FIREBASE_DATABASE_URL: https://campusaura-12c16.firebaseio.com
       # Firebase service account 
       FIREBASE_SERVICE_ACCOUNT_KEY: /run/secrets/firebase-key
-      # CORS: 
+      # CORS:  
       CORS_ALLOWED_ORIGINS: http://localhost:5173,http://localhost:5174,http://localhost:5175
     secrets:
       - firebase-key
@@ -33,7 +33,7 @@ services:
 # Secrets
 secrets:
   firebase-key:
-    file: ./CampusAura-backend/src/main/resources/firebase-service-account.json
+    file: ./src/main/resources/firebase-service-account.json
 
 # Networks
 networks:

--- a/src/main/java/com/example/campusaura/config/FirebaseConfig.java
+++ b/src/main/java/com/example/campusaura/config/FirebaseConfig.java
@@ -11,11 +11,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import jakarta.annotation.PostConstruct;
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Base64;
 
 @Configuration
 @ConditionalOnProperty(name = "firebase.enabled", havingValue = "true", matchIfMissing = true)
@@ -58,9 +60,10 @@ public class FirebaseConfig {
     }
 
     /**
-     * Opens the Firebase service account key from either:
-     * 1. A classpath resource (local dev): "classpath:firebase-service-account.json"
-     * 2. An absolute file path (Docker secret): "/run/secrets/firebase-key"
+     * Opens the Firebase service account key from one of three sources:
+     * 1. Classpath resource (local dev):     "classpath:firebase-service-account.json"
+     * 2. Absolute file path (Docker secret): "/run/secrets/firebase-key"
+     * 3. Base64-encoded JSON (Azure / CI):   "base64:<base64-encoded-json>"
      */
     private InputStream openServiceAccountStream() throws IOException {
         if (serviceAccountKeyPath.startsWith("classpath:")) {
@@ -70,6 +73,11 @@ public class FirebaseConfig {
                 throw new IOException("Classpath resource not found: " + resourceName);
             }
             return stream;
+        } else if (serviceAccountKeyPath.startsWith("base64:")) {
+            // Base64-encoded JSON passed as environment variable (e.g. Azure Container Apps secret)
+            String encoded = serviceAccountKeyPath.substring("base64:".length());
+            byte[] decoded = Base64.getDecoder().decode(encoded.trim());
+            return new ByteArrayInputStream(decoded);
         } else {
             // Absolute file path (Docker secret mounted at /run/secrets/)
             if (!Files.exists(Paths.get(serviceAccountKeyPath))) {


### PR DESCRIPTION
This pull request introduces a robust, production-ready deployment workflow for the backend service, with significant improvements to deployment automation, Docker configuration, and Firebase configuration flexibility. The main highlights are the addition of a GitHub Actions pipeline for building, deploying, and verifying the backend on Azure Container Apps, enhancements to Docker and Compose setup, and support for multiple ways to provide the Firebase service account key (including via base64-encoded secrets for cloud deployments).

**Deployment Automation:**

* Added `.github/workflows/deploy-backend.yml` to automate building, pushing, deploying, and health-checking the backend on Azure Container Apps using GitHub Actions. This workflow builds the Docker image, pushes it to Azure Container Registry, updates the container app with the new image, and performs a health check to verify deployment success.

**Docker and Compose Improvements:**

* Updated `Dockerfile` to remove the `wget` installation and Docker healthcheck (now handled externally), ensure the app runs as a non-root user, and simplify the build and runtime stages for better security and compatibility with Azure Container Apps.
* Changed `docker-compose.yml` to use the correct build context (project root) and updated the path to the Firebase secret to match the new directory structure. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L8-R8) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L36-R36)

**Firebase Configuration Flexibility:**

* Enhanced `FirebaseConfig.java` to support loading the Firebase service account key from a base64-encoded environment variable (for cloud deployments), in addition to classpath and file-based secrets. This allows seamless configuration across local, Docker, and cloud environments. [[1]](diffhunk://#diff-8cf3bbaac318ee158b7ab55e75ea6daacc6be9925e9a566b3fdbd2f75450047bR14-R20) [[2]](diffhunk://#diff-8cf3bbaac318ee158b7ab55e75ea6daacc6be9925e9a566b3fdbd2f75450047bL61-R66) [[3]](diffhunk://#diff-8cf3bbaac318ee158b7ab55e75ea6daacc6be9925e9a566b3fdbd2f75450047bR76-R80)